### PR TITLE
feat: add chunked media upload for files larger than 32MB

### DIFF
--- a/lib/snapchat_api/resources/media.rb
+++ b/lib/snapchat_api/resources/media.rb
@@ -4,6 +4,9 @@ require "mime/types"
 module SnapchatApi
   module Resources
     class Media < Base
+      CHUNKED_UPLOAD_THRESHOLD = 32_000_000
+      CHUNK_SIZE = 25 * 1024 * 1024
+
       def list_all(ad_account_id:, params: {})
         params[:limit] ||= 50
 
@@ -35,6 +38,8 @@ module SnapchatApi
       end
 
       def upload(media_id:, file_path:, params: {})
+        return upload_chunked(media_id: media_id, file_path: file_path, params: params) if File.size(file_path) > CHUNKED_UPLOAD_THRESHOLD
+
         mime_type = MIME::Types.type_for(file_path).first.content_type
 
         upload_params = {
@@ -42,6 +47,52 @@ module SnapchatApi
         }
 
         response = client.request(:post, "media/#{media_id}/upload", upload_params, {"Content-Type" => "multipart/form-data"})
+        response.body["result"]
+      end
+
+      def upload_chunked(media_id:, file_path:, params: {})
+        mime_type = MIME::Types.type_for(file_path).first.content_type
+        file_name = File.basename(file_path)
+        file_size = File.size(file_path)
+        number_of_parts = (file_size.to_f / CHUNK_SIZE).ceil
+
+        init_response = client.request(
+          :post,
+          "media/#{media_id}/multipart-upload-v2?action=INIT",
+          {
+            file_name: file_name,
+            file_size: file_size.to_s,
+            number_of_parts: number_of_parts.to_s
+          },
+          {"Content-Type" => "multipart/form-data"}
+        )
+        upload_id = init_response.body["upload_id"]
+        add_path = init_response.body["add_path"]
+        finalize_path = init_response.body["finalize_path"]
+
+        File.open(file_path, "rb") do |file|
+          part_number = 1
+          while (chunk = file.read(CHUNK_SIZE))
+            client.request(
+              :post,
+              add_path,
+              {
+                file: Faraday::UploadIO.new(StringIO.new(chunk), mime_type, file_name),
+                part_number: part_number.to_s,
+                upload_id: upload_id
+              },
+              {"Content-Type" => "multipart/form-data"}
+            )
+            part_number += 1
+          end
+        end
+
+        response = client.request(
+          :post,
+          finalize_path,
+          {upload_id: upload_id, file_name: file_name},
+          {"Content-Type" => "multipart/form-data"}
+        )
         response.body["result"]
       end
 

--- a/spec/snapchat_api/resources/media_spec.rb
+++ b/spec/snapchat_api/resources/media_spec.rb
@@ -1,3 +1,5 @@
+require "tempfile"
+
 RSpec.describe SnapchatApi::Resources::Media do
   let(:client) do
     SnapchatApi::Client.new(
@@ -49,6 +51,75 @@ RSpec.describe SnapchatApi::Resources::Media do
       expect(media).to include("id", "name", "type")
       expect(media["name"]).to eq("Test Media")
       expect(media["type"]).to eq("IMAGE")
+    end
+  end
+
+  describe "#upload_chunked" do
+    let(:media_file) do
+      file = Tempfile.new(["chunked_video", ".mp4"])
+      file.binmode
+      file.write("a" * 20)
+      file.rewind
+      file
+    end
+
+    let(:init_response) do
+      {
+        request_status: "SUCCESS",
+        upload_id: "upload-123",
+        add_path: "/us/v1/media/#{media_id}/multipart-upload-v2?action=ADD",
+        finalize_path: "/us/v1/media/#{media_id}/multipart-upload-v2?action=FINALIZE"
+      }
+    end
+
+    let(:finalize_response) do
+      {
+        request_status: "SUCCESS",
+        result: {
+          "id" => media_id,
+          "name" => "Chunked Video",
+          "type" => "VIDEO",
+          "media_status" => "PENDING_UPLOAD"
+        }
+      }
+    end
+
+    before do
+      stub_const("SnapchatApi::Resources::Media::CHUNKED_UPLOAD_THRESHOLD", 10)
+      stub_const("SnapchatApi::Resources::Media::CHUNK_SIZE", 8)
+    end
+
+    after { media_file.close! }
+
+    it "uploads the file in parts via multipart-upload-v2" do
+      init_stub = stub_request(:post, "https://adsapi.snapchat.com/v1/media/#{media_id}/multipart-upload-v2?action=INIT")
+        .to_return(status: 200, body: init_response.to_json, headers: {"Content-Type" => "application/json"})
+      add_stub = stub_request(:post, "https://adsapi.snapchat.com/us/v1/media/#{media_id}/multipart-upload-v2?action=ADD")
+        .to_return(status: 200, body: {request_status: "SUCCESS"}.to_json, headers: {"Content-Type" => "application/json"})
+      finalize_stub = stub_request(:post, "https://adsapi.snapchat.com/us/v1/media/#{media_id}/multipart-upload-v2?action=FINALIZE")
+        .to_return(status: 200, body: finalize_response.to_json, headers: {"Content-Type" => "application/json"})
+
+      result = media_resource.upload_chunked(media_id: media_id, file_path: media_file.path)
+
+      expect(result["id"]).to eq(media_id)
+      expect(result["media_status"]).to eq("PENDING_UPLOAD")
+      expect(init_stub).to have_been_requested
+      expect(add_stub).to have_been_requested.times(3)
+      expect(finalize_stub).to have_been_requested
+    end
+
+    it "is used automatically by #upload when the file exceeds the threshold" do
+      stub_request(:post, "https://adsapi.snapchat.com/v1/media/#{media_id}/multipart-upload-v2?action=INIT")
+        .to_return(status: 200, body: init_response.to_json, headers: {"Content-Type" => "application/json"})
+      add_stub = stub_request(:post, "https://adsapi.snapchat.com/us/v1/media/#{media_id}/multipart-upload-v2?action=ADD")
+        .to_return(status: 200, body: {request_status: "SUCCESS"}.to_json, headers: {"Content-Type" => "application/json"})
+      stub_request(:post, "https://adsapi.snapchat.com/us/v1/media/#{media_id}/multipart-upload-v2?action=FINALIZE")
+        .to_return(status: 200, body: finalize_response.to_json, headers: {"Content-Type" => "application/json"})
+
+      result = media_resource.upload(media_id: media_id, file_path: media_file.path)
+
+      expect(result["id"]).to eq(media_id)
+      expect(add_stub).to have_been_requested.times(3)
     end
   end
 


### PR DESCRIPTION
Snapchat rejects single-request media uploads above 33554432 bytes with error E2056 ("Media size is too large"). This adds support for the [chunked upload flow](https://developers.snap.com/api/marketing-api/Ads-API/media#upload-media---chunked) so large videos can be uploaded.

## Changes
- `Media#upload_chunked` implements the `multipart-upload-v2` flow: INIT (declares `file_name`, `file_size`, `number_of_parts`), ADD for each 25MB chunk, FINALIZE. The ADD/FINALIZE requests use the `add_path`/`finalize_path` returned by INIT.
- `Media#upload` automatically dispatches to `upload_chunked` when the file exceeds 32MB, so existing callers get large-file support without changes.

## Tests
- WebMock-based specs for the chunked flow (part count, finalize result, auto-dispatch), with `stub_const` to shrink chunk sizes.
- Full media spec run: 7 examples, 0 failures. StandardRB clean.