### PR TITLE
fix: apply access token per request so token refresh takes effect

### DIFF
--- a/lib/snapchat_api/client.rb
+++ b/lib/snapchat_api/client.rb
@@ -25,7 +25,6 @@ module SnapchatApi
 
     def connection
       @connection ||= Faraday.new(url: ADS_URL) do |conn|
-        conn.headers["Authorization"] = "Bearer #{@access_token}"
         conn.headers["Content-Type"] = "application/json"
 
         conn.options.timeout = 60
@@ -45,6 +44,8 @@ module SnapchatApi
 
     def request(method, path, params = {}, headers = {})
       response = connection.run_request(method, path, nil, headers) do |req|
+        req.headers["Authorization"] = "Bearer #{@access_token}"
+
         case method
         when :get, :delete
           req.params = params

--- a/spec/snapchat_api/client_spec.rb
+++ b/spec/snapchat_api/client_spec.rb
@@ -147,4 +147,35 @@ RSpec.describe SnapchatApi::Client do
       end
     end
   end
+
+  describe "authorization header" do
+    it "sends the current access token on every request" do
+      stub = stub_request(:get, "https://adsapi.snapchat.com/v1/test")
+        .with(headers: {"Authorization" => "Bearer test_access_token"})
+        .to_return(status: 200, body: {"request_status" => "SUCCESS"}.to_json, headers: {"Content-Type" => "application/json"})
+
+      client.request(:get, "test")
+
+      expect(stub).to have_been_requested
+    end
+
+    it "uses the new token after the access token is refreshed on the same client" do
+      first = stub_request(:get, "https://adsapi.snapchat.com/v1/test")
+        .with(headers: {"Authorization" => "Bearer test_access_token"})
+        .to_return(status: 401, body: {"message" => "unauthorized"}.to_json, headers: {"Content-Type" => "application/json"})
+
+      expect { client.request(:get, "test") }.to raise_error(SnapchatApi::AuthenticationError)
+
+      client.access_token = "refreshed_access_token"
+      second = stub_request(:get, "https://adsapi.snapchat.com/v1/test")
+        .with(headers: {"Authorization" => "Bearer refreshed_access_token"})
+        .to_return(status: 200, body: {"request_status" => "SUCCESS"}.to_json, headers: {"Content-Type" => "application/json"})
+
+      response = client.request(:get, "test")
+
+      expect(response.status).to eq(200)
+      expect(first).to have_been_requested
+      expect(second).to have_been_requested
+    end
+  end
 end


### PR DESCRIPTION
The Faraday connection was memoized with the Authorization header baked in at build time, so calling refresh_tokens! updated @access_token but subsequent requests kept sending the old (expired) token, surfacing as "unauthorized". Set the Authorization header per request from the current access token instead.